### PR TITLE
Delete space in depends section of description to work with devtools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: MCMC for Spike and Slab Regression
 Author: Steven L. Scott <stevescott@google.com>
 Maintainer: Steven L. Scott <stevescott@google.com>
 Description: Spike and slab regression a la McCulloch and George (1997).
-Depends: Boom (>= 0.4) , R (>= 3.1.0)
+Depends: Boom (>= 0.4), R (>= 3.1.0)
 LinkingTo: BH (>= 1.15.0-2)
 Suggests: MASS
 Version: 0.6.0


### PR DESCRIPTION
The current DESCRIPTION file throws an error when used with install_github due to the way parse_deps parses the Depends section because of the space after the parenthesis.  This is just a deletion of the space so that it can work properly with install_github.  An example of the change is shown below:

**> devtools::parse_deps("Depends: Boom (>= 0.4) , R (>= 3.1.0)")**
Error in devtools::parse_deps("Depends: Boom (>= 0.4) , R (>= 3.1.0)") : 
  Invalid comparison operator in dependency: >= 
**> devtools::parse_deps("Depends: Boom (>= 0.4), R (>= 3.1.0)")**
           name compare version
1 Depends: Boom      >=     0.4
